### PR TITLE
chore: [IO-6178] build static binaries + newer sqlite 3.45+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS tippecanoe-builder
+FROM ubuntu:24.04 AS tippecanoe-builder
 
 RUN apt-get update \
   && apt-get -y install make gcc g++ libsqlite3-dev zlib1g-dev
@@ -11,7 +11,7 @@ RUN make
 CMD make test
 
 # Using multistage build reduces the docker image size by alot by only copying the needed binaries
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 RUN apt-get update \
   && apt-get -y install libsqlite3-0 \
   && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CC := $(CC)
 CXX := $(CXX)
 CFLAGS := $(CFLAGS) -fPIE -DBUILD_INFO=$(BUILD_INFO)
 CXXFLAGS := $(CXXFLAGS) -std=c++17 -fPIE -DBUILD_INFO=$(BUILD_INFO)
-LDFLAGS := $(LDFLAGS)
+LDFLAGS := $(LDFLAGS) -static
 WARNING_FLAGS := -Wall -Wshadow -Wsign-compare -Wextra -Wunreachable-code -Wuninitialized -Wshadow
 RELEASE_FLAGS := -O3 -DNDEBUG
 DEBUG_FLAGS := -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
@@ -57,7 +57,7 @@ H = $(wildcard *.h) $(wildcard *.hpp)
 C = $(wildcard *.c) $(wildcard *.cpp)
 
 INCLUDES = -I/usr/local/include -I. -Iclipper2/include
-LIBS = -L/usr/local/lib
+LIBS = -L/usr/local/lib -L/usr/lib
 
 tippecanoe: geojson.o jsonpull/jsonpull.o tile.o pool.o mbtiles.o geometry.o projection.o memfile.o mvt.o serial.o main.o platform.o text.o dirtiles.o pmtiles_file.o plugin.o read_json.o write_json.o geobuf.o flatgeobuf.o evaluator.o geocsv.o csv.o geojson-loop.o json_logger.o visvalingam.o compression.o clip.o sort.o attribute.o thread.o shared_borders.o clipper2/src/clipper.engine.o
 	$(CXX) $(PG) $(LIBS) $(FINAL_FLAGS) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -lm -lz -lsqlite3 -lpthread


### PR DESCRIPTION
Running tipp with larger data (500k+ wide features+) frequently produces a corrupt database. libsqlite3 - 3.40.1-2+deb12u1 is the suspect. We can't reproduce this on dev machine using 3.45.1-1ubuntu2.1.